### PR TITLE
fix libshim_gui.cpp not found error

### DIFF
--- a/libshims/Android.mk
+++ b/libshims/Android.mk
@@ -1,3 +1,5 @@
+LOCAL_PATH := $(call my-dir)
+
 include $(CLEAR_VARS)
 LOCAL_SRC_FILES := libshim_gui.cpp
 LOCAL_SHARED_LIBRARIES := libskia libgui


### PR DESCRIPTION
I'm getting libshim_gui.cpp not found error when building and this commit seems to fix it.